### PR TITLE
Remove Rails from namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased Changes
 ------------------
 
+* Issue - Remove the `Rails` namespace from this gem, and place `VERSION` on the Railtie.
+
 0.1.0 (2024-11-16)
 ------------------
 

--- a/lib/aws-record-rails.rb
+++ b/lib/aws-record-rails.rb
@@ -14,14 +14,11 @@ require 'aws-record'
 
 module Aws
   module Record
-    module Rails
+    class Railtie < ::Rails::Railtie
       VERSION = File.read(File.expand_path('../VERSION', __dir__)).strip
 
-      # @api private
-      class Railtie < ::Rails::Railtie
-        rake_tasks do
-          load 'tasks/aws_record/migrate.rake'
-        end
+      rake_tasks do
+        load 'tasks/aws_record/migrate.rake'
       end
     end
   end

--- a/lib/aws-record-rails.rb
+++ b/lib/aws-record-rails.rb
@@ -14,6 +14,7 @@ require 'aws-record'
 
 module Aws
   module Record
+    # Rails tasks for Aws::Record
     class Railtie < ::Rails::Railtie
       VERSION = File.read(File.expand_path('../VERSION', __dir__)).strip
 


### PR DESCRIPTION
Fixes #16

Removes the `Rails` namespace and places VERSION on the Railtie instead. Everything is still loaded and `Rails` is assumed to be the root namespace.